### PR TITLE
Added error message when Registering with a new user with the same us…

### DIFF
--- a/src/main/java/SYSC6/Project/Main_Controller.java
+++ b/src/main/java/SYSC6/Project/Main_Controller.java
@@ -62,6 +62,14 @@ public class Main_Controller {
     @PostMapping("/Create")
     public String create(@ModelAttribute Login login, Model model, RedirectAttributes attributes){
         model.addAttribute("login", login);
+        ArrayList<User> users = checkUser();
+        for(User user : users){
+            if(user.getUsername().equals(login.getUsername())){
+                attributes.addFlashAttribute("message", "Username already Exists pick another");
+                return "redirect:/Registration";
+            }
+        }
+
         id = createUser(login.getUsername(), login.getPassword());
         return "redirect:/compare_talent";
     }


### PR DESCRIPTION
The error message for when creating a new user with the same username as an existing user has been added and needs to be approved. The code change has been done to a simple method within main controller yet is the failsafe version of what we will be converted to CURL later-on